### PR TITLE
Restructure test data

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -73,8 +73,11 @@ def container(request, container_runtime):
 
 
 def pytest_generate_tests(metafunc):
-    # Finds container_type.
-    # If necessary, you can override the detection by setting a variable "container_type" in your module.
+    """Finds container_type.
+
+    If necessary, you can override the detection by setting a variable
+    "container_type" in your module.
+    """
     container_type = getattr(metafunc.module, "container_type", "")
     if container_type == "":
         container_type = (
@@ -88,10 +91,10 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(
             "container",
             [
-                (ver, containers[container_type][ver])
-                for ver in containers[container_type]
+                (versioned_container.version, versioned_container.full_url)
+                for versioned_container in containers[container_type]
             ],
-            ids=[ver for ver in containers[container_type]],
+            ids=[ver.version for ver in containers[container_type]],
             indirect=True,
         )
 

--- a/matryoshka_tester/cmds.py
+++ b/matryoshka_tester/cmds.py
@@ -25,22 +25,22 @@ async def pull_container(url):
 
 
 # CLI
-def list_containers():
+def list_containers() -> None:
     pt = PrettyTable()
     pt.field_names = ["Language", "Version", "URL"]
     pt.align = "l"
-    for language, versionsdict in containers.items():
-        for version in versionsdict:
-            pt.add_row([language, version, versionsdict[version]])
+    for language, versions_list in containers.items():
+        for version in versions_list:
+            pt.add_row([language, version.version, version])
     print(pt)
 
 
 async def fetch_containers(all_containers=False, container_type=""):
     containers_urls = []
-    for language, versionsdict in containers.items():
+    for language, versions_list in containers.items():
         if language == container_type or all_containers:
-            for version in versionsdict:
-                containers_urls.append(versionsdict[version])
+            for version in versions_list:
+                containers_urls.append(version.full_url)
     results = await asyncio.gather(*map(pull_container, containers_urls))
     for result in results:
         print(f"[stdout]\n{result[0].decode().strip()}\n[stderr]\n{result[1].decode().strip()}")

--- a/matryoshka_tester/cmds.py
+++ b/matryoshka_tester/cmds.py
@@ -12,13 +12,16 @@ from prettytable import PrettyTable
 # Do real stuff
 async def pull_container(url):
     """Pulls the container given in url with docker CLI"""
-    runtime = get_selected_runtime()
+    cmd = f"{get_selected_runtime().runner_binary} pull {url}"
     process = await asyncio.create_subprocess_shell(
-        f"{runtime.runner_binary} pull {url}",
+        cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    return await process.communicate()
+    res = await process.communicate()
+    if process.returncode != 0:
+        raise RuntimeError(f"command '{cmd}' failed with {process.returncode}")
+    return res
 
 
 # CLI

--- a/matryoshka_tester/data.py
+++ b/matryoshka_tester/data.py
@@ -1,28 +1,128 @@
-containers = dict()
-containers["go"] = {
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+
+go_containers = {
     "1.16": "registry.opensuse.org/devel/bci/images/bci/golang-devel:16",
     "1.15": "registry.opensuse.org/devel/bci/images/bci/golang-devel:15",
-    "1.14": "registry.opensuse.org/devel/bci/images/bci/golang-devel:14"
+    "1.14": "registry.opensuse.org/devel/bci/images/bci/golang-devel:14",
 }
-containers["node"] = {
+node_containers = {
     "15": "registry.opensuse.org/home/fcrozat/matryoshka/containers_node15/node15:latest",
     "14": "registry.opensuse.org/home/fcrozat/matryoshka/containers_node14/node14:latest",
     "12": "registry.opensuse.org/home/fcrozat/matryoshka/containers_node12/node12:latest",
 }
-containers["openjdk-devel"] = {
+openjdk_devel_containers = {
     "16": "registry.opensuse.org/devel/bci/images/bci/openjdk-devel:16",
     "15": "registry.opensuse.org/devel/bci/images/bci/openjdk-devel:15",
     "14": "registry.opensuse.org/devel/bci/images/bci/openjdk-devel:14",
     "11": "registry.opensuse.org/devel/bci/images/bci/openjdk-devel:11",
 }
-containers["openjdk"] = {
+openjdk_containers = {
     "16": "registry.opensuse.org/devel/bci/images/bci/openjdk:16",
     "15": "registry.opensuse.org/devel/bci/images/bci/openjdk:15",
     "14": "registry.opensuse.org/devel/bci/images/bci/openjdk:14",
     "11": "registry.opensuse.org/devel/bci/images/bci/openjdk:11",
 }
-containers["python"] = {
+python_containers = {
     "3.9": "registry.opensuse.org/home/fcrozat/matryoshka/containers_python39/python39:latest",
     "3.8": "registry.opensuse.org/home/fcrozat/matryoshka/containers_python38/python38:latest",
     "3.6": "registry.opensuse.org/home/fcrozat/matryoshka/containers_python36/python36:latest",
+}
+
+
+@dataclass
+class VersionedLanguageContainer:
+    """
+    Storage class representing a single container that is built in the Open
+    Build Service, published into a repository and represents a language or
+    tech stack at a certain version (that needn't match the container tag).
+    """
+
+    #: name of the project in the build service where the container is built
+    project: str
+    #: repository in which the container is published
+    repository: str
+    #: the version of this container
+    version: str
+    #: name and tag/version of this container
+    name_and_tag: str
+    #: optional prefix appended to the full url after the repository
+    prefix: Optional[str] = None
+    #: url of the registry under which the build service publishes OCI images
+    registry_base_url: str = "registry.opensuse.org/"
+
+    def __post_init__(self) -> None:
+        if self.registry_base_url[-1] != "/":
+            self.registry_base_url = self.registry_base_url + "/"
+
+    @property
+    def full_url(self) -> str:
+        if len(self.name_and_tag.split(":")) not in (1, 2):
+            raise ValueError(
+                f"got an invalid value for {self.name_and_tag=}, "
+                "contains a wrong number of ':'"
+            )
+        elements = [self.project.replace(":", "/"), self.repository]
+        if self.prefix:
+            elements.append(self.prefix)
+        elements.append(self.name_and_tag)
+        return self.registry_base_url + "/".join(
+            elem.strip("/") for elem in elements
+        )
+
+    def __str__(self) -> str:
+        return self.full_url
+
+    def __repr__(self) -> str:
+        return f"{self.name_and_tag} from {self.project}/{self.repository}"
+
+
+def container_from_url(
+    url: str, version: Optional[str] = None, url_includes_prefix: bool = False
+) -> VersionedLanguageContainer:
+    """"""
+    path_elements = url.split("/")
+    name_and_tag = path_elements[-1]
+
+    repository_index = -3 if url_includes_prefix else -2
+    repository = path_elements[repository_index]
+    registry_base_url = path_elements[0]
+    prefix = path_elements[-2] if url_includes_prefix else None
+    lang_container = VersionedLanguageContainer(
+        project=":".join(path_elements[1:repository_index]),
+        repository=repository,
+        version=version or name_and_tag.split(":")[1],
+        name_and_tag=name_and_tag,
+        prefix=prefix,
+        registry_base_url=registry_base_url,
+    )
+
+    assert lang_container.full_url == url, (
+        f"original url '{url}' and reconstructed url "
+        + f"'{lang_container.full_url}' do not match"
+    )
+
+    return lang_container
+
+
+containers: Dict[str, List[VersionedLanguageContainer]] = {
+    "go": [
+        container_from_url(url, version, url_includes_prefix=True)
+        for version, url in go_containers.items()
+    ],
+    "node": [
+        container_from_url(url, version, False)
+        for version, url in node_containers.items()
+    ],
+    "openjdk": [
+        container_from_url(url) for url in openjdk_containers.values()
+    ],
+    "openjdk-devel": [
+        container_from_url(url) for url in openjdk_devel_containers.values()
+    ],
+    "python": [
+        container_from_url(url, version, False)
+        for version, url in python_containers.items()
+    ],
 }


### PR DESCRIPTION
This changes how the `containers` dictionary is created in the `data` module. While this is quite a fat change with no immediately visible benefit, it will become handy later on, as we can query each container for its project, version, repository, etc.pp. I am currently working on a rabbitmq listener that will automatically run the CI if OBS publishes a container to the the repositories (this would be doable with the previous dictionary, but super ugly imho).