### PR TITLE
Cleanup the test_node file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,36 @@ easy.
 
 You can use the convenience tools from conftest:
 
-* If you are using the "container" fixture, your test will auto generate the right tests for _all_ the versions of your language. This is auto loaded, and doesn't need anything from your side except using the keyword "container"
-* If you want to _skip_ some of those tests, use the decorator named `restrict_to_version`. This decorator accepts a list of strings matching the versions from `data.py`. To use it, add first `from conftest import restrict_to_version` and then wrap your code like this (assuming openjdk here):
+* If you are using the "container" fixture, your test will auto generate the right tests for _all_ the versions of your language. This is auto loaded, and doesn't need anything from your side except using the keyword "container". See below for more details.
+* If you want to _skip_ some of those tests, use the decorator named `restrict_to_version`, which accepts a list of strings of the versions for which to run the test. See below for more details.
+
+### The container fixture
+
+The `container` fixture contains the black magic to run commands for all versions of a language container.
+If you need to run a test only for certain versions of a language stack, you have the following three options (by order of preference):
+
+1. Use the [`restrict_to_version`](#the-restrict_to_version-decorator) decorator to limit which containers your test applies to.
+2. Create your own fixture
+3. Modify the `container` fixture.
+The container fixture automatically finds the testfile filename, uses it to infer the language of the container under test,
+and starts all the necessary containers. See also `conftest.py`.
+
+### The restrict_to_version decorator
+
+This decorator accepts a list of strings matching the versions from `data.py`.
+
+To use it:
+
+1. add `from conftest import restrict_to_version` to your imports.
+2. wrap your test function as follow (assuming openjdk here):
+
 ```Python
 @restrict_to_version(['11'])
 def mytest(container):
     pass
 ```
+
+In the example above, the test function `mytest` will only run for the `openjdk:11` container, instead of all the containers for openjdk.
 
 ## Running all tests
 

--- a/test_node.py
+++ b/test_node.py
@@ -6,15 +6,6 @@ from typing import Any
 import pytest
 
 
-from conftest import restrict_to_version
-
-
-# Container fixture contains the black magic to run command on all the different kind of nodes
-# per language.
-# If you need to run a test for a single version, create your own fixture
-# You should think of reusing the `container` fixture from yours.
-
-
 @dataclass(frozen=True)
 class NpmPackageTest:
     build_command: str = ""
@@ -28,9 +19,8 @@ class NpmPackageTest:
     @property
     def test_command(self) -> str:
         return f"""git clone {self.repository_url} &&
-cd {self.repo_name} &&
-{self.build_command}
-"""
+            cd {self.repo_name} &&
+            {self.build_command}"""
 
     def __str__(self) -> str:
         return self.repo_name
@@ -39,12 +29,8 @@ cd {self.repo_name} &&
         return pytest.param(self, id=self.__str__(), marks=self.marks or ())
 
 
-# The container fixture automatically finds the file from the test, guesses the language, and starts all the necessary containers
-# See also conftest.py
 def test_node_version(container):
-    assert f"v{container.version}" in container.connection.check_output(
-        "node -v"
-    )
+    assert f"v{container.version}" in container.connection.check_output("node -v")
 
 
 # We don't care about the version, just test that the command seem to work
@@ -72,24 +58,25 @@ def test_npm(container):
             ),
             NpmPackageTest(
                 repository_url="https://github.com/visionmedia/debug.git",
-                build_command="""npm install &&
-                npm run lint &&
-                npm run test:node
-""",
+                build_command="""
+                    npm install &&
+                    npm run lint &&
+                    npm run test:node
+                    """,
             ),
             NpmPackageTest(
                 repository_url="https://github.com/expressjs/express.git",
                 build_command="""npm config set shrinkwrap false &&
-                npm rm --silent --save-dev connect-redis &&
-                npm run test-ci &&
-                npm run lint
-""",
+                    npm rm --silent --save-dev connect-redis &&
+                    npm run test-ci &&
+                    npm run lint
+                    """,
             ),
             NpmPackageTest(
                 build_command="""npm install -g grunt-cli &&
-                npm install &&
-                grunt test
-""",
+                    npm install &&
+                    grunt test
+                    """,
                 repository_url="https://github.com/moment/moment",
             ),
             NpmPackageTest(
@@ -99,15 +86,15 @@ def test_npm(container):
             NpmPackageTest(
                 build_command="yarn --frozen-lockfile && yarn test",
                 repository_url="https://github.com/facebook/react.git",
-                marks=pytest.mark.skip(reason="too fat to run in parallel")
+                marks=pytest.mark.skip(reason="too fat to run in parallel"),
             ),
             NpmPackageTest(
                 build_command="""yarn install &&
-                npm install --no-save "react@~16" "react-dom@~16" &&
-                yarn run pretest &&
-                yarn run tests-only &&
-                yarn run build
-""",
+                    npm install --no-save "react@~16" "react-dom@~16" &&
+                    yarn run pretest &&
+                    yarn run tests-only &&
+                    yarn run build
+                    """,
                 repository_url="https://github.com/facebook/prop-types",
                 marks=pytest.mark.skip(reason="Broken for some reason"),
             ),


### PR DESCRIPTION
Without this, documentation seems intertwined in the test_node
file, where the documentation should be complete in the README
instead.

This should fix it.

At the same time, I am cleaning up so that black is happy.