### PR TITLE
Unify the tests that clone git repositories

### DIFF
--- a/test_go.py
+++ b/test_go.py
@@ -1,17 +1,23 @@
 import pytest
-import testinfra
+
+from matryoshka_tester.helpers import GitRepositoryBuild
 
 
 def test_go_version(container):
     assert container.version in container.connection.check_output("go version")
 
 
-def test_kured(container):
-    cmd = container.connection.run(
-        """git clone https://github.com/weaveworks/kured.git &&
-        cd kured &&
-        make cmd/kured/kured
-        """
-    )
+@pytest.mark.parametrize(
+    "container_git_clone",
+    [
+        GitRepositoryBuild(
+            repository_url="https://github.com/weaveworks/kured.git",
+            build_command="make cmd/kured/kured",
+        ).to_pytest_param()
+    ],
+    indirect=["container_git_clone"],
+)
+def test_kured(container, container_git_clone):
+    cmd = container.connection.run(container_git_clone.test_command)
     print(cmd.stdout)
     assert cmd.rc == 0


### PR DESCRIPTION
We have a lot of tests that are essentially just `git clone $url && cd basename($url) && $build_cmd` but implemented in different places. To reduce code duplication, we add a new fixture `git_clone`, that executes the correct git clone (supporting tags as well) inside the container and returns the test parameters.

This allows us to reuse some common datastructures from the `ContainerBuild` class as well.