### PR TITLE
Test base container and its openssl behaviour

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,7 @@ from matryoshka_tester.helpers import (
     get_selected_runtime,
     GitRepositoryBuild,
 )
-
+from matryoshka_tester.fips import host_fips_enabled, host_fips_supported
 
 ContainerData = namedtuple("Container", ["version", "image", "connection"])
 
@@ -136,3 +136,11 @@ def restrict_to_version(versions):
         return wrapper
 
     return inner
+
+
+with_fips = pytest.mark.skipif(
+    not host_fips_enabled(), reason="host not running in FIPS 140 mode"
+)
+without_fips = pytest.mark.skipif(
+    host_fips_enabled(), reason="host running in FIPS 140 mode"
+)

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,6 @@ from matryoshka_tester.helpers import (
     get_selected_runtime,
     GitRepositoryBuild,
 )
-from matryoshka_tester.fips import host_fips_enabled, host_fips_supported
 
 ContainerData = namedtuple("Container", ["version", "image", "connection"])
 
@@ -136,11 +135,3 @@ def restrict_to_version(versions):
         return wrapper
 
     return inner
-
-
-with_fips = pytest.mark.skipif(
-    not host_fips_enabled(), reason="host not running in FIPS 140 mode"
-)
-without_fips = pytest.mark.skipif(
-    host_fips_enabled(), reason="host running in FIPS 140 mode"
-)

--- a/matryoshka_tester/data/containers.json
+++ b/matryoshka_tester/data/containers.json
@@ -1,5 +1,11 @@
 [
     {
+        "type": "base",
+        "repo": "devel/bci/images",
+        "image": "bci/base",
+        "tag": "latest"
+    },
+    {
         "type": "openjdk-devel",
         "repo": "devel/bci/images",
         "image": "bci/openjdk-devel",

--- a/matryoshka_tester/fips.py
+++ b/matryoshka_tester/fips.py
@@ -1,0 +1,45 @@
+import os
+
+
+NONFIPS_DIGESTS = (
+    "blake2b512",
+    "blake2s256",
+    "gost",
+    "md4",
+    "md5",
+    "mdc2",
+    "rmd160",
+    "sm3",
+)
+
+FIPS_DIGESTS = (
+    "sha1",
+    "sha224",
+    "sha256",
+    "sha3-224",
+    "sha3-256",
+    "sha3-384",
+    "sha3-512",
+    "sha384",
+    "sha512",
+    "sha512-224",
+    "sha512-256",
+    "shake128",
+    "shake256",
+)
+
+ALL_DIGESTS = NONFIPS_DIGESTS + FIPS_DIGESTS
+
+
+def host_fips_supported():
+    import os.path
+
+    return os.path.exists("/proc/sys/crypto/fips_enabled")
+
+
+def host_fips_enabled():
+    if not host_fips_supported():
+        return False
+
+    with open("/proc/sys/crypto/fips_enabled") as f:
+        return f.read().strip() == "1"

--- a/matryoshka_tester/fips.py
+++ b/matryoshka_tester/fips.py
@@ -32,8 +32,6 @@ ALL_DIGESTS = NONFIPS_DIGESTS + FIPS_DIGESTS
 
 
 def host_fips_supported():
-    import os.path
-
     return os.path.exists("/proc/sys/crypto/fips_enabled")
 
 

--- a/matryoshka_tester/fips.py
+++ b/matryoshka_tester/fips.py
@@ -32,13 +32,13 @@ FIPS_DIGESTS = (
 ALL_DIGESTS = NONFIPS_DIGESTS + FIPS_DIGESTS
 
 
-def host_fips_supported():
-    return os.path.exists("/proc/sys/crypto/fips_enabled")
+def host_fips_supported(fipsfile: str = "/proc/sys/crypto/fips_enabled"):
+    return os.path.exists(fipsfile)
 
 
-def host_fips_enabled():
-    if not host_fips_supported():
+def host_fips_enabled(fipsfile: str = "/proc/sys/crypto/fips_enabled"):
+    if not host_fips_supported(fipsfile):
         return False
 
-    with open("/proc/sys/crypto/fips_enabled") as f:
+    with open(fipsfile) as f:
         return f.read().strip() == "1"

--- a/matryoshka_tester/fips.py
+++ b/matryoshka_tester/fips.py
@@ -1,10 +1,11 @@
 import os
 
+# Gost doesn't seem to work.
 
 NONFIPS_DIGESTS = (
     "blake2b512",
     "blake2s256",
-    "gost",
+    # "gost",
     "md4",
     "md5",
     "mdc2",

--- a/test_base.py
+++ b/test_base.py
@@ -1,9 +1,23 @@
-from matryoshka_tester.fips import NONFIPS_DIGESTS, FIPS_DIGESTS, ALL_DIGESTS
-from conftest import with_fips, without_fips
+import pytest
+from matryoshka_tester.fips import (
+    host_fips_enabled,
+    host_fips_supported,
+    NONFIPS_DIGESTS,
+    FIPS_DIGESTS,
+    ALL_DIGESTS,
+)
 
 
 def test_passwd_present(container):
-    assert container.file("/etc/passwd").exists
+    assert container.connection.file("/etc/passwd").exists
+
+
+with_fips = pytest.mark.skipif(
+    not host_fips_enabled(), reason="host not running in FIPS 140 mode"
+)
+without_fips = pytest.mark.skipif(
+    host_fips_enabled(), reason="host running in FIPS 140 mode"
+)
 
 
 @with_fips

--- a/test_base.py
+++ b/test_base.py
@@ -7,11 +7,12 @@ from matryoshka_tester.fips import (
     ALL_DIGESTS,
 )
 
-
+# Generic tests
 def test_passwd_present(container):
     assert container.connection.file("/etc/passwd").exists
 
 
+# FIPS tests
 with_fips = pytest.mark.skipif(
     not host_fips_enabled(), reason="host not running in FIPS 140 mode"
 )

--- a/test_base.py
+++ b/test_base.py
@@ -1,0 +1,23 @@
+from matryoshka_tester.fips import NONFIPS_DIGESTS, FIPS_DIGESTS, ALL_DIGESTS
+from conftest import with_fips, without_fips
+
+
+def test_passwd_present(container):
+    assert container.file("/etc/passwd").exists
+
+
+@with_fips
+def test_openssl_fips_hashes(container):
+    for md in NONFIPS_DIGESTS:
+        cmd = container.connection.run(f"openssl {md} /dev/null")
+        assert cmd.rc != 0
+        assert "not a known digest" in cmd.stdout
+
+    for md in FIPS_DIGESTS:
+        container.connection.run_expect([0], f"openssl {md} /dev/null")
+
+
+@without_fips
+def test_openssl_hashes(container):
+    for md in ALL_DIGESTS:
+        container.connection.run_expect([0], f"openssl {md} /dev/null")

--- a/test_unit.py
+++ b/test_unit.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 
 from matryoshka_tester.parse_data import build_containerlist
+from matryoshka_tester.fips import host_fips_enabled, host_fips_supported
 
 
 def test_default_containerlist():
@@ -17,3 +18,21 @@ def test_buildcontainerlist(tmp_path):
         fw.write("{}")
     with pytest.raises(TypeError):
         build_containerlist(tmpfile)
+
+
+def test_host_fips_supported(tmp_path):
+    fipsfile = tmp_path / "fips"
+    fipsfile.write_text("")
+    assert host_fips_supported(f"{fipsfile}")
+
+
+def test_host_fips_enabled(tmp_path):
+    fipsfile = tmp_path / "fips"
+    fipsfile.write_text("1")
+    assert host_fips_enabled(f"{fipsfile}")
+
+
+def test_host_fips_disabled(tmp_path):
+    fipsfile = tmp_path / "fips"
+    fipsfile.write_text("")
+    assert not host_fips_enabled(f"{fipsfile}")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = unit, python, node, go, openjdk, openjdk-devel, multistage
+envlist = unit, base, python, node, go, openjdk, openjdk-devel, multistage
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
This is based on the latest data structure refactor (and therefore needs rebase when it's merged).

This tests the base container, including its openssl behaviour on FIPS and non FIPS hosts.