### PR TITLE
[CI] Only run podman tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         toxenv: ${{fromJson(needs.gentestmatrix.outputs.matrix)}}
         container_runtime:
-          - DOCKER
           - PODMAN
     steps:
     - name: checkout source code


### PR DESCRIPTION
The docker tests are the same, so it's not really worth running.
If a contributor runs docker without podman, that will be enough.