### PR TITLE
Mark the visionmedia/debug build as failure

### DIFF
--- a/test_node.py
+++ b/test_node.py
@@ -39,6 +39,9 @@ def test_npm(container):
                     npm run lint &&
                     npm run test:node
                     """,
+                marks=pytest.mark.xfail(
+                    reason="Unexpected use of file extension 'js' for './browser.js' when building src/index.js"
+                ),
             ),
             GitRepositoryBuild(
                 repository_url="https://github.com/expressjs/express.git",


### PR DESCRIPTION
Without this, node tests break.

This is a problem, as we are making those mandatory.

This fixes it by marking the test as _expected failure_ instead
of skipped, so that we can track when it's working again, and
re-enable it.